### PR TITLE
Add mobile-friendly icons and header logo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { UndoIcon, ResetIcon, ClearIcon } from "./icons";
 
 /**
  * Ascension Tracker – Mobile/PWA-first
@@ -112,7 +113,7 @@ function TapBtn({
       onClick={onClick}
       className="flex-1 min-w-[68px] h-12 rounded-2xl text-base font-semibold shadow-sm
                  border border-white/10 bg-white/10 backdrop-blur
-                 active:scale-[.98] transition"
+                 active:scale-[.98] transition flex items-center justify-center gap-2"
     >
       {children}
     </button>
@@ -317,6 +318,7 @@ export default function App() {
     >
       {/* topo compacto */}
       <header className="px-3 pt-3 pb-2 flex items-center gap-2">
+        <img src={ASSET("icon-512.png")} alt="Ascension" className="w-8 h-8" />
         <h1 className="text-xl font-extrabold tracking-tight">Ascension</h1>
         <span className="text-xs text-white/70">Tracker</span>
       </header>
@@ -364,9 +366,18 @@ export default function App() {
                    border-t border-white/10 px-3 py-2"
       >
         <div className="max-w-[720px] mx-auto grid grid-cols-3 gap-2">
-          <TapBtn onClick={undo} title="Desfazer última ação">Desfazer</TapBtn>
-          <TapBtn onClick={resetRound} title="Zerar gastos da rodada">Nova</TapBtn>
-          <TapBtn onClick={clearAll} title="Voltar ao padrão">Limpar</TapBtn>
+          <TapBtn onClick={undo} title="Desfazer última ação">
+          <UndoIcon />
+          Desfazer
+          </TapBtn>
+          <TapBtn onClick={resetRound} title="Zerar gastos da rodada">
+          <ResetIcon />
+          Nova
+          </TapBtn>
+          <TapBtn onClick={clearAll} title="Voltar ao padrão">
+          <ClearIcon />
+          Limpar
+          </TapBtn>
         </div>
       </nav>
     </div>

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+/** Simple SVG icons for mobile actions */
+export function UndoIcon({ className = "w-5 h-5" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M9 5 5 9l4 4" />
+      <path d="M5 9h6a4 4 0 1 1 0 8h-1" />
+    </svg>
+  );
+}
+
+export function ResetIcon({ className = "w-5 h-5" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4 4v6h6" />
+      <path d="M20 20v-6h-6" />
+      <path d="M20 9a7 7 0 0 0-12-5.3L4 10" />
+      <path d="M4 15a7 7 0 0 0 12 5.3L20 14" />
+    </svg>
+  );
+}
+
+export function ClearIcon({ className = "w-5 h-5" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6v14a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V6" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add custom SVG icons for undo, reset and clear actions
- show app icon in header for stronger Ascension branding
- enhance tap button layout to center icons and labels for mobile

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6cb760960833284924b20f012df65