### PR TITLE
feat: improve mobile UI with navigation icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { UndoIcon, NewRoundIcon, ClearIcon } from "./icons";
 
 /**
  * Ascension Tracker – Mobile/PWA-first
@@ -110,7 +111,7 @@ function TapBtn({
     <button
       title={title}
       onClick={onClick}
-      className="flex-1 min-w-[68px] h-12 rounded-2xl text-base font-semibold shadow-sm
+      className="flex items-center justify-center gap-2 flex-1 min-w-[68px] h-12 rounded-2xl text-base font-semibold shadow-sm
                  border border-white/10 bg-white/10 backdrop-blur
                  active:scale-[.98] transition"
     >
@@ -364,9 +365,18 @@ export default function App() {
                    border-t border-white/10 px-3 py-2"
       >
         <div className="max-w-[720px] mx-auto grid grid-cols-3 gap-2">
-          <TapBtn onClick={undo} title="Desfazer última ação">Desfazer</TapBtn>
-          <TapBtn onClick={resetRound} title="Zerar gastos da rodada">Nova</TapBtn>
-          <TapBtn onClick={clearAll} title="Voltar ao padrão">Limpar</TapBtn>
+          <TapBtn onClick={undo} title="Desfazer última ação">
+            <UndoIcon className="w-5 h-5" />
+            <span>Desfazer</span>
+          </TapBtn>
+          <TapBtn onClick={resetRound} title="Zerar gastos da rodada">
+            <NewRoundIcon className="w-5 h-5" />
+            <span>Nova</span>
+          </TapBtn>
+          <TapBtn onClick={clearAll} title="Voltar ao padrão">
+            <ClearIcon className="w-5 h-5" />
+            <span>Limpar</span>
+          </TapBtn>
         </div>
       </nav>
     </div>

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+export function UndoIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 15L3 9m0 0 6-6M3 9h12a6 6 0 010 12h-3"
+      />
+    </svg>
+  );
+}
+
+export function NewRoundIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M16.023 9.348h4.177V5.17m-.478 4.359a8.25 8.25 0 11-3.006-5.793"
+      />
+    </svg>
+  );
+}
+
+export function ClearIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 6h18M8 6v12a2 2 0 002 2h4a2 2 0 002-2V6m-5 0V4h-4v2m2 5v6m4-6v6"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable SVG icons for undo, new round and clear actions
- show icons and labels in mobile bottom navigation
- refine TapBtn layout to align icons and text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6cc0e1fcc8332bb4bada10d1f0aef